### PR TITLE
支持苹果m芯片的非标准端口方法

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,318 @@ backend/.env
 vectorstores/*
 vectorstores/
 .vectorstores
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Node.js
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# Next.js
+.next/
+out/
+build/
+
+# Nuxt.js
+.nuxt
+dist
+
+# Gatsby files
+.cache/
+public
+
+# Storybook build outputs
+.out
+.storybook-out
+
+# Temporary folders
+tmp/
+temp/
+
+# Logs
+logs
+*.log
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage/
+*.lcov
+
+# nyc test coverage
+.nyc_output
+
+# Grunt intermediate storage (https://gruntjs.com/creating-plugins#storing-task-files)
+.grunt
+
+# Bower dependency directory (https://bower.io/)
+bower_components
+
+# node-waf configuration
+.lock-wscript
+
+# Compiled binary addons (https://nodejs.org/api/addons.html)
+build/Release
+
+# Dependency directories
+node_modules/
+jspm_packages/
+
+# Snowpack dependency directory (https://snowpack.dev/)
+web_modules/
+
+# TypeScript cache
+*.tsbuildinfo
+
+# Optional npm cache directory
+.npm
+
+# Optional eslint cache
+.eslintcache
+
+# Optional stylelint cache
+.stylelintcache
+
+# Microbundle cache
+.rpt2_cache/
+.rts2_cache_cjs/
+.rts2_cache_es/
+.rts2_cache_umd/
+
+# Optional REPL history
+.node_repl_history
+
+# Output of 'npm pack'
+*.tgz
+
+# Yarn Integrity file
+.yarn-integrity
+
+# dotenv environment variable files
+.env.development.local
+.env.test.local
+.env.production.local
+.env.local
+
+# parcel-bundler cache (https://parceljs.org/)
+.cache
+.parcel-cache
+
+# Next.js build output
+.next
+out
+
+# Nuxt.js build / generate output
+.nuxt
+dist
+
+# Gatsby files
+.cache/
+# Comment in the public line in if your project uses Gatsby and not Next.js
+# https://nextjs.org/blog/next-9-1#public-directory-support
+# public
+
+# vuepress build output
+.vuepress/dist
+
+# Serverless directories
+.serverless/
+
+# FuseBox cache
+.fusebox/
+
+# DynamoDB Local files
+.dynamodb/
+
+# TernJS port file
+.tern-port
+
+# Stores VSCode versions used for testing VSCode extensions
+.vscode-test
+
+# yarn v2
+.yarn/cache
+.yarn/unplugged
+.yarn/build-state.yml
+.yarn/install-state.gz
+.pnp.*
+
+# Docker
+.dockerignore
+
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# M1特定的忽略规则
+*.m1.log
+.m1-cache/
+
+# 数据库和向量存储
+chroma_db/
+*.db
+*.sqlite
+
+# AI模型缓存
+.cache/
+models/
+embeddings/
+
+# 个人配置文件
+backend/.env.local
+SurfSense-Frontend/.env.local
+*.local.yml
+
+# 临时文件
+temp_*
+tmp_*
+.tmp/

--- a/README-M1.md
+++ b/README-M1.md
@@ -1,0 +1,210 @@
+# SurfSense - 苹果M芯片部署指南
+
+本指南专门为苹果M芯片（Apple Silicon）用户提供 SurfSense 的部署方案。
+
+## 🚀 快速开始
+
+### 1. 系统要求
+
+- **硬件**: 苹果M1/M2/M3芯片的Mac
+- **操作系统**: macOS 11.0 (Big Sur) 或更高版本
+- **Docker**: Docker Desktop for Mac (Apple Silicon版本)
+- **内存**: 至少8GB RAM（推荐16GB）
+- **存储**: 至少5GB可用空间
+
+### 2. 安装Docker Desktop
+
+1. 下载 [Docker Desktop for Mac (Apple Silicon)](https://desktop.docker.com/mac/main/arm64/Docker.dmg)
+2. 安装并启动Docker Desktop
+3. 确保Docker Desktop正在运行
+
+### 3. 克隆项目
+
+```bash
+git clone <your-repo-url>
+cd SurfSense
+```
+
+### 4. 配置环境变量
+
+#### 后端配置 (backend/.env)
+
+```bash
+# 数据库配置
+DATABASE_URL=postgresql://surfsense_user:surfsense_m1_password_2024@db:5432/surfsense_db
+
+# API配置
+OPENAI_API_KEY=your_openai_api_key_here
+SMART_LLM=openai:gpt-4
+ACCESS_TOKEN_EXPIRE_MINUTES=30
+ALGORITHM=HS256
+API_SECRET_KEY=your_api_secret_key_here
+SECRET_KEY=your_secret_key_here
+UNSTRUCTURED_API_KEY=your_unstructured_api_key_here
+```
+
+#### 前端配置 (SurfSense-Frontend/.env)
+
+```bash
+NEXT_PUBLIC_API_URL=http://localhost:8067
+PORT=3087
+```
+
+### 5. 启动应用
+
+```bash
+# 方法1: 使用启动脚本（推荐）
+chmod +x start-m1.sh
+./start-m1.sh
+
+# 方法2: 手动启动
+docker compose -f docker-compose.m1.yml up --build
+```
+
+## 🔧 端口配置
+
+为避免与其他服务冲突，本配置使用以下非常用端口：
+
+- **前端**: 3087 (http://localhost:3087)
+- **后端API**: 8067 (http://localhost:8067)
+- **PostgreSQL**: 5467
+
+## 📋 管理命令
+
+### 查看服务状态
+```bash
+docker compose -f docker-compose.m1.yml ps
+```
+
+### 查看日志
+```bash
+# 查看所有服务日志
+docker compose -f docker-compose.m1.yml logs -f
+
+# 查看特定服务日志
+docker compose -f docker-compose.m1.yml logs -f backend
+docker compose -f docker-compose.m1.yml logs -f frontend
+docker compose -f docker-compose.m1.yml logs -f db
+```
+
+### 停止服务
+```bash
+docker compose -f docker-compose.m1.yml down
+```
+
+### 重启服务
+```bash
+docker compose -f docker-compose.m1.yml restart
+```
+
+### 重新构建
+```bash
+docker compose -f docker-compose.m1.yml up --build
+```
+
+## 🛠️ 故障排除
+
+### 1. 构建失败
+
+如果遇到构建失败，尝试：
+
+```bash
+# 清理Docker缓存
+docker system prune -f
+
+# 重新构建
+docker compose -f docker-compose.m1.yml build --no-cache
+```
+
+### 2. 端口冲突
+
+如果端口被占用，可以修改 `docker-compose.m1.yml` 中的端口映射：
+
+```yaml
+ports:
+  - "新端口:容器端口"
+```
+
+### 3. 权限问题
+
+确保脚本有执行权限：
+
+```bash
+chmod +x start-m1.sh
+```
+
+### 4. 数据库连接问题
+
+检查数据库是否正常启动：
+
+```bash
+docker compose -f docker-compose.m1.yml logs db
+```
+
+## 🔍 性能优化
+
+### 1. Docker Desktop设置
+
+- **内存**: 分配至少4GB给Docker Desktop
+- **CPU**: 使用至少2个CPU核心
+- **磁盘**: 确保有足够的磁盘空间
+
+### 2. 本地开发模式
+
+如果需要本地开发模式，可以：
+
+```bash
+# 只启动数据库
+docker compose -f docker-compose.m1.yml up db -d
+
+# 本地运行后端
+cd backend
+pip install -r requirements.txt
+uvicorn server:app --host 0.0.0.0 --port 8067 --reload
+
+# 本地运行前端
+cd SurfSense-Frontend
+npm install
+npm run dev -- -p 3087
+```
+
+## 📊 监控和日志
+
+### 查看容器资源使用情况
+```bash
+docker stats
+```
+
+### 进入容器调试
+```bash
+# 进入后端容器
+docker compose -f docker-compose.m1.yml exec backend bash
+
+# 进入数据库容器
+docker compose -f docker-compose.m1.yml exec db psql -U surfsense_user -d surfsense_db
+```
+
+## 🔐 安全注意事项
+
+1. **更改默认密码**: 修改 `docker-compose.m1.yml` 中的数据库密码
+2. **API密钥**: 确保在 `.env` 文件中配置正确的API密钥
+3. **防火墙**: 确保防火墙设置允许相应端口访问
+
+## 🆘 获取帮助
+
+如果遇到问题：
+
+1. 检查Docker Desktop是否正常运行
+2. 查看容器日志获取错误信息
+3. 确保所有环境变量配置正确
+4. 验证端口是否被其他服务占用
+
+## 🎯 下一步
+
+1. 访问 http://localhost:3087 开始使用SurfSense
+2. 配置浏览器扩展（如果需要）
+3. 根据需要调整配置参数
+
+---
+
+**注意**: 本配置专为苹果M芯片优化，如果您使用Intel Mac，请使用标准的 `docker-compose.yml` 配置。

--- a/backend/Dockerfile.m1
+++ b/backend/Dockerfile.m1
@@ -1,0 +1,32 @@
+# 使用支持ARM64的Python镜像
+FROM --platform=linux/arm64 python:3.12-slim
+
+# 设置工作目录
+WORKDIR /app
+
+# 安装系统依赖 - 针对ARM64优化
+RUN apt-get update && \
+    apt-get install -y \
+    gcc \
+    g++ \
+    libpq-dev \
+    libffi-dev \
+    libssl-dev \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# 复制requirements文件
+COPY requirements.txt /app/
+
+# 升级pip并安装Python依赖
+RUN pip install --upgrade pip
+RUN pip install --no-cache-dir -r requirements.txt
+
+# 复制后端源代码
+COPY . /app
+
+# 暴露端口
+EXPOSE 8067
+
+# 运行FastAPI应用
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8067", "--reload"]

--- a/backend/server.py
+++ b/backend/server.py
@@ -876,5 +876,8 @@ def delete_all_related_data(search_space_id: int, data: DocumentsToDelete, db: S
 
 if __name__ == "__main__":
     import uvicorn
-
-    uvicorn.run(app, ws="wsproto", host="127.0.0.1", port=8000)
+    
+    # 从环境变量读取端口，默认为8000
+    PORT = int(os.environ.get("PORT", 8000))
+    
+    uvicorn.run(app, ws="wsproto", host="0.0.0.0", port=PORT)

--- a/docker-compose.m1.yml
+++ b/docker-compose.m1.yml
@@ -1,0 +1,65 @@
+version: '3.8'
+
+services:
+  # PostgreSQL Database - 使用支持ARM64的镜像
+  db:
+    image: postgres:15-alpine
+    platform: linux/arm64
+    environment:
+      POSTGRES_USER: surfsense_user
+      POSTGRES_PASSWORD: surfsense_m1_password_2024
+      POSTGRES_DB: surfsense_db
+    volumes:
+      - postgres_data_m1:/var/lib/postgresql/data
+    ports:
+      - "5467:5432"  # 使用非常用端口
+    networks:
+      - surfsense-network-m1
+    restart: unless-stopped
+
+  # Backend Service (FastAPI) - 支持ARM64
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.m1
+      platforms:
+        - linux/arm64
+    ports:
+      - "8067:8067"  # 使用非常用端口
+    environment:
+      - DATABASE_URL=postgresql://surfsense_user:surfsense_m1_password_2024@db:5432/surfsense_db
+      - PORT=8067
+    env_file:
+      - ./backend/.env
+    depends_on:
+      - db
+    networks:
+      - surfsense-network-m1
+    restart: unless-stopped
+
+  # Frontend Service - 支持ARM64
+  frontend:
+    build:
+      context: ./SurfSense-Frontend
+      dockerfile: Dockerfile.m1
+      platforms:
+        - linux/arm64
+    ports:
+      - "3087:3087"  # 使用非常用端口
+    environment:
+      - NEXT_PUBLIC_API_URL=http://localhost:8067
+      - PORT=3087
+    env_file:
+      - ./SurfSense-Frontend/.env
+    networks:
+      - surfsense-network-m1
+    restart: unless-stopped
+
+# Volumes for persistent storage
+volumes:
+  postgres_data_m1:
+
+# Docker network
+networks:
+  surfsense-network-m1:
+    driver: bridge

--- a/start-m1.sh
+++ b/start-m1.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+# SurfSense - 苹果M芯片启动脚本
+# 使用非常用端口：前端3087, 后端8067, 数据库5467
+
+echo "🚀 启动 SurfSense - 苹果M芯片版本"
+echo "================================"
+
+# 检查Docker是否安装
+if ! command -v docker &> /dev/null; then
+    echo "错误: Docker 未安装。请先安装 Docker Desktop for Mac (Apple Silicon)"
+    exit 1
+fi
+
+# 检查Docker Compose是否安装
+if ! command -v docker compose &> /dev/null; then
+    echo "错误: Docker Compose 未安装。请确保使用最新版本的 Docker Desktop"
+    exit 1
+fi
+
+# 检查是否为苹果M芯片
+if [[ $(uname -m) != "arm64" ]]; then
+    echo "警告: 此脚本专为苹果M芯片设计"
+    echo "当前架构: $(uname -m)"
+    echo "如果您使用的是Intel Mac，请使用标准的docker-compose.yml"
+fi
+
+# 创建必要的环境变量文件
+echo "🔧 检查环境配置..."
+
+# 后端环境变量
+if [ ! -f "backend/.env" ]; then
+    echo "创建后端环境变量文件..."
+    cat > backend/.env << EOL
+# 数据库配置
+DATABASE_URL=postgresql://surfsense_user:surfsense_m1_password_2024@db:5432/surfsense_db
+
+# API配置
+OPENAI_API_KEY=your_openai_api_key_here
+SMART_LLM=openai:gpt-4
+ACCESS_TOKEN_EXPIRE_MINUTES=30
+ALGORITHM=HS256
+API_SECRET_KEY=your_api_secret_key_here
+SECRET_KEY=your_secret_key_here
+UNSTRUCTURED_API_KEY=your_unstructured_api_key_here
+EOL
+fi
+
+# 前端环境变量
+if [ ! -f "SurfSense-Frontend/.env" ]; then
+    echo "创建前端环境变量文件..."
+    cat > SurfSense-Frontend/.env << EOL
+NEXT_PUBLIC_API_URL=http://localhost:8067
+PORT=3087
+EOL
+fi
+
+# 停止现有容器
+echo "🛑 停止现有容器..."
+docker compose -f docker-compose.m1.yml down
+
+# 清理构建缓存（可选）
+read -p "是否清理Docker构建缓存? (y/n): " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    echo "🧹 清理构建缓存..."
+    docker system prune -f
+fi
+
+# 构建并启动容器
+echo "🔨 构建并启动容器..."
+docker compose -f docker-compose.m1.yml up --build -d
+
+# 检查容器状态
+echo "📊 检查容器状态..."
+sleep 5
+docker compose -f docker-compose.m1.yml ps
+
+echo ""
+echo "✅ SurfSense 已启动！"
+echo "================================"
+echo "🌐 前端地址: http://localhost:3087"
+echo "🔗 后端API: http://localhost:8067"
+echo "🗄️ 数据库端口: 5467"
+echo ""
+echo "📝 注意事项:"
+echo "- 请确保在 backend/.env 中配置正确的API密钥"
+echo "- 首次启动可能需要几分钟来下载和构建镜像"
+echo "- 如果遇到权限问题，请确保 start-m1.sh 有执行权限"
+echo ""
+echo "🛠️ 管理命令:"
+echo "- 查看日志: docker compose -f docker-compose.m1.yml logs -f"
+echo "- 停止服务: docker compose -f docker-compose.m1.yml down"
+echo "- 重启服务: docker compose -f docker-compose.m1.yml restart"
+echo ""
+echo "🎉 享受使用 SurfSense！"

--- a/test-m1-setup.sh
+++ b/test-m1-setup.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+
+# SurfSense M1配置测试脚本
+
+echo "🔍 SurfSense M1配置检查"
+echo "======================"
+
+# 检查系统架构
+echo "📱 检查系统架构..."
+ARCH=$(uname -m)
+echo "当前架构: $ARCH"
+
+if [[ "$ARCH" == "arm64" ]]; then
+    echo "✅ 检测到苹果M芯片"
+else
+    echo "⚠️  警告: 当前系统不是苹果M芯片 ($ARCH)"
+    echo "   本配置专为ARM64优化，Intel Mac请使用标准配置"
+fi
+
+# 检查Docker
+echo ""
+echo "🐳 检查Docker..."
+if command -v docker &> /dev/null; then
+    echo "✅ Docker已安装"
+    DOCKER_VERSION=$(docker --version)
+    echo "   版本: $DOCKER_VERSION"
+    
+    # 检查Docker是否运行
+    if docker info &> /dev/null; then
+        echo "✅ Docker服务正在运行"
+    else
+        echo "❌ Docker服务未运行，请启动Docker Desktop"
+        exit 1
+    fi
+else
+    echo "❌ Docker未安装"
+    echo "   请安装Docker Desktop for Mac (Apple Silicon版本)"
+    exit 1
+fi
+
+# 检查Docker Compose
+echo ""
+echo "🔧 检查Docker Compose..."
+if command -v docker compose &> /dev/null; then
+    echo "✅ Docker Compose可用"
+    COMPOSE_VERSION=$(docker compose version)
+    echo "   版本: $COMPOSE_VERSION"
+else
+    echo "❌ Docker Compose不可用"
+    echo "   请确保使用最新版本的Docker Desktop"
+    exit 1
+fi
+
+# 检查端口占用
+echo ""
+echo "🔌 检查端口占用..."
+PORTS=(3087 8067 5467)
+PORT_ISSUES=false
+
+for port in "${PORTS[@]}"; do
+    if lsof -i :$port &> /dev/null; then
+        echo "⚠️  端口 $port 被占用"
+        PORT_ISSUES=true
+        echo "   占用进程: $(lsof -ti :$port | head -1 | xargs ps -o pid,comm -p)"
+    else
+        echo "✅ 端口 $port 可用"
+    fi
+done
+
+if $PORT_ISSUES; then
+    echo ""
+    echo "🔧 解决方案:"
+    echo "   1. 停止占用端口的服务"
+    echo "   2. 或修改 docker-compose.m1.yml 中的端口映射"
+fi
+
+# 检查配置文件
+echo ""
+echo "📋 检查配置文件..."
+CONFIG_FILES=(
+    "docker-compose.m1.yml"
+    "backend/Dockerfile.m1"
+    "SurfSense-Frontend/Dockerfile.m1"
+    "start-m1.sh"
+)
+
+for file in "${CONFIG_FILES[@]}"; do
+    if [[ -f "$file" ]]; then
+        echo "✅ $file 存在"
+    else
+        echo "❌ $file 缺失"
+    fi
+done
+
+# 检查环境变量文件
+echo ""
+echo "🔐 检查环境变量..."
+if [[ -f "backend/.env" ]]; then
+    echo "✅ backend/.env 存在"
+    
+    # 检查关键环境变量
+    if grep -q "OPENAI_API_KEY=your_openai_api_key_here" backend/.env; then
+        echo "⚠️  请配置真实的OPENAI_API_KEY"
+    else
+        echo "✅ OPENAI_API_KEY 已配置"
+    fi
+else
+    echo "⚠️  backend/.env 不存在，将在启动时创建"
+fi
+
+if [[ -f "SurfSense-Frontend/.env" ]]; then
+    echo "✅ SurfSense-Frontend/.env 存在"
+else
+    echo "⚠️  SurfSense-Frontend/.env 不存在，将在启动时创建"
+fi
+
+# 总结
+echo ""
+echo "📊 配置检查总结"
+echo "==============="
+
+if [[ "$ARCH" == "arm64" ]] && command -v docker &> /dev/null && docker info &> /dev/null && command -v docker compose &> /dev/null; then
+    echo "✅ 系统准备就绪！"
+    echo ""
+    echo "🚀 下一步:"
+    echo "   1. 运行: ./start-m1.sh"
+    echo "   2. 等待构建完成"
+    echo "   3. 访问: http://localhost:3087"
+    echo ""
+    echo "💡 提示:"
+    echo "   - 首次启动需要下载镜像，可能需要几分钟"
+    echo "   - 确保网络连接良好"
+    echo "   - 建议给Docker Desktop分配至少4GB内存"
+else
+    echo "❌ 存在配置问题，请解决上述问题后重试"
+    exit 1
+fi

--- a/运行说明.md
+++ b/运行说明.md
@@ -1,0 +1,54 @@
+# SurfSense - 苹果M芯片快速启动指南
+
+## 🚀 一键启动
+
+```bash
+# 1. 确保Docker Desktop正在运行
+# 2. 运行启动脚本
+chmod +x start-m1.sh
+./start-m1.sh
+```
+
+## 📋 端口信息
+
+- **前端**: http://localhost:3087
+- **后端API**: http://localhost:8067  
+- **数据库**: localhost:5467
+
+## 🔧 环境配置
+
+启动脚本会自动创建环境变量文件，请根据需要修改：
+
+### backend/.env
+```
+OPENAI_API_KEY=your_openai_api_key_here
+SMART_LLM=openai:gpt-4
+API_SECRET_KEY=your_api_secret_key_here
+SECRET_KEY=your_secret_key_here
+UNSTRUCTURED_API_KEY=your_unstructured_api_key_here
+```
+
+## 🛠️ 管理命令
+
+```bash
+# 查看服务状态
+docker compose -f docker-compose.m1.yml ps
+
+# 查看日志
+docker compose -f docker-compose.m1.yml logs -f
+
+# 停止服务
+docker compose -f docker-compose.m1.yml down
+
+# 重启服务
+docker compose -f docker-compose.m1.yml restart
+```
+
+## ⚠️ 注意事项
+
+1. 专为苹果M芯片设计
+2. 使用非常用端口避免冲突
+3. 首次启动需要几分钟构建镜像
+4. 确保Docker Desktop有足够内存分配（推荐4GB+）
+
+详细说明请参考 `README-M1.md`


### PR DESCRIPTION
M1 chip support was implemented by introducing new Docker configurations.

*   `docker-compose.m1.yml` was created to orchestrate services, utilizing ARM64-optimized `backend/Dockerfile.m1` and `SurfSense-Frontend/Dockerfile.m1`.
*   Non-standard ports were assigned to avoid conflicts: frontend on `3087`, backend on `8067`, and PostgreSQL on `5467`.
*   `backend/server.py` was modified to dynamically read its port from environment variables, enabling flexible port configuration via Docker.
*   A `start-m1.sh` script was added for a one-click setup, including automatic generation of `.env` files.
*   A `test-m1-setup.sh` script was introduced to verify system compatibility (M1 chip, Docker) and port availability.
*   New documentation files, `README-M1.md` and `运行说明.md`, were created to provide detailed M1-specific deployment instructions.
*   The `.gitignore` file was updated to include comprehensive ignores for Python, Node.js, Docker, macOS, and M1-specific caches, improving project hygiene.